### PR TITLE
Add support for an external close action

### DIFF
--- a/RCTSFSafariViewController.m
+++ b/RCTSFSafariViewController.m
@@ -37,5 +37,9 @@ RCT_EXPORT_METHOD(openURL:(NSString *)urlString params:(NSDictionary *)params) {
   });
 }
 
+RCT_EXPORT_METHOD(close) {
+    UIViewController *rootViewController = [[[UIApplication sharedApplication] delegate] window].rootViewController;
+    [rootViewController dismissViewControllerAnimated:YES completion:nil];
+}
 
 @end

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ RCTSFSafariViewController.open('https://google.com/');
 RCTSFSafariViewController.open('https://google.com/', {
   tintColor: '#90c3d4',
 });
+
+// Close the browser modal from your React Native code if needed
+RCTSFSafariViewController.close();
+
 ```
 
 ## Events

--- a/index.ios.js
+++ b/index.ios.js
@@ -24,6 +24,10 @@ var RCTSFSafariViewControllerExport = {
     SFSafariViewController.openURL(url, parsedOptions);
   },
 
+  close: function() {
+    SFSafariViewController.close();
+  },
+
   addEventListener(eventName, listener) {
     if(eventName == 'onLoad')
       NativeAppEventEmitter.addListener('SFSafariViewControllerDidLoad', listener);


### PR DESCRIPTION
Hello,

- I use the SFSafariViewController for an oAuth like process.
- I use deeplinking to notify my app when the process is finished and I need to close the SFSafariViewController when the process is finished.

This pull request adds support for an external close action that can be used from React Native.