### PR TITLE
Update imports for react native 0.40

### DIFF
--- a/RCTSFSafariViewController.h
+++ b/RCTSFSafariViewController.h
@@ -1,6 +1,6 @@
-#import "RCTBridgeModule.h"
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConvert.h>
+#import <React/RCTEventDispatcher.h>
 #import <UIKit/UIKit.h>
 
 @import SafariServices;


### PR DESCRIPTION
This PR updates the imports to the react native libraries to be compatible with RN 0.40 .

This is a breaking change that will make the library incompatible with projects using RN < 0.40 .

More information at https://github.com/facebook/react-native/releases/tag/v0.40.0