### PR TITLE
Can present modal on top of a modal

### DIFF
--- a/RCTSFSafariViewController.m
+++ b/RCTSFSafariViewController.m
@@ -14,6 +14,10 @@ RCT_EXPORT_METHOD(openURL:(NSString *)urlString params:(NSDictionary *)params) {
   NSURL *url = [[NSURL alloc] initWithString:urlString];
 
   UIViewController *rootViewController = [[[UIApplication sharedApplication] delegate] window].rootViewController;
+  while(rootViewController.presentedViewController) {
+    rootViewController = rootViewController.presentedViewController;
+  }
+
   SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:url];
   UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:safariViewController];
 


### PR DESCRIPTION
Provides the ability to present the SFSafariViewController on top of an already presented modal. This wasn't supported and would give you a view hierarchy warning.