### PR TITLE
Bugfix for Android crash - "Attempted to redefine property 'removeEventListener'" on app startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ RCTSFSafariViewController.removeEventListener('onDismiss', this.someDismissListe
 
 // alternative approach
 const subscription = RCTSFSafariViewController.addEventListener('onLoad', () => console.log('RCTSafariViewController is now visible!'));
-RCTSFSafariViewController.removeEventListener(subscription);
+subscription.remove();
 
 ```
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -42,10 +42,6 @@ var RCTSFSafariViewControllerExport = {
 
     if(eventName == 'onDismiss')
       NativeAppEventEmitter.removeListener('SFSafariViewControllerDismissed', listener);
-  },
-
-  removeEventListener(subscription) {
-    subscription.remove();
   }
 };
 


### PR DESCRIPTION
Weirdly this happens on Android only even though this change was in a .ios.js file... So I've update my previous change to tackle with this issue. https://www.evernote.com/l/AYp-52WeAgxAy6DG3jkTd1sFYn3GmeEsLXs